### PR TITLE
commenting out double cb call in catch{}.

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -16,7 +16,6 @@ module.exports = function after(scope, cb) {
                 fs.renameSync(fs.realpathSync(scope.rootPath + '/bower_components'), destination);
             } catch(ex) {
                 cb.log.error('Couldn\'t move bower_components folder to ' + destination + ', try running `bower install`.');
-                cb();
             }
             cb.log.info('Bower done installing components to ' + fs.realpathSync(destination));
             cb();


### PR DESCRIPTION
ChaosD figured this out:

https://github.com/chiefy/sails-generate-frontend-angular/issues/3

After this change, I was able to successfully do this:
http://chiefy.github.io/2014/06/24/using-sails-generate-frontend-angular.html
![screen shot 2014-10-06 at 3 29 54 am](https://cloud.githubusercontent.com/assets/690735/4523107/0ec1f6dc-4d33-11e4-8024-361ed917b1d7.png)

as well as load default page:

![screen shot 2014-10-06 at 3 30 55 am](https://cloud.githubusercontent.com/assets/690735/4523113/24a13382-4d33-11e4-920e-55e9fe007e13.png)
