### PR TITLE
Double callback on "sails new xyz"

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -16,7 +16,6 @@ module.exports = function after(scope, cb) {
                 fs.renameSync(fs.realpathSync(scope.rootPath + '/bower_components'), destination);
             } catch(ex) {
                 cb.log.error('Couldn\'t move bower_components folder to ' + destination + ', try running `bower install`.');
-                cb();
             }
             cb.log.info('Bower done installing components to ' + fs.realpathSync(destination));
             cb();


### PR DESCRIPTION
Callback should not be called if there was an exception. This would result in the callback being called twice.
Maybe even the whole moving bower components routine should be removed.

See #3

(Thanks to @spunkedy´for the screenshots and the initial pull request)

After this change, I was able to successfully do this:
http://chiefy.github.io/2014/06/24/using-sails-generate-frontend-angular.html
![image](https://cloud.githubusercontent.com/assets/331779/4529728/b1f1e236-4d79-11e4-8d2e-476b515b41cf.png)

as well as load default page:
![image](https://cloud.githubusercontent.com/assets/690735/4523113/24a13382-4d33-11e4-920e-55e9fe007e13.png)
